### PR TITLE
Fitur: Kustomisasi CSS, Penempatan CTA, dan Shortcode

### DIFF
--- a/cta-otomatis.php
+++ b/cta-otomatis.php
@@ -23,6 +23,7 @@ define( 'COA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 // Memuat file-file yang dibutuhkan dari folder masing-masing
 require_once COA_PLUGIN_PATH . 'admin/admin-settings.php';
 require_once COA_PLUGIN_PATH . 'includes/frontend-display.php';
+require_once COA_PLUGIN_PATH . 'includes/shortcodes.php';
 
 /**
  * Mendaftarkan stylesheet untuk tampilan frontend.
@@ -55,3 +56,15 @@ function coa_enqueue_fontawesome() {
     }
 }
 add_action( 'wp_enqueue_scripts', 'coa_enqueue_fontawesome' );
+
+/**
+ * Memuat CSS Kustom di header.
+ */
+function coa_load_custom_css() {
+    $options = get_option( 'coa_settings' );
+    if ( ! empty( $options['coa_custom_css'] ) ) {
+        $custom_css = wp_strip_all_tags( $options['coa_custom_css'] );
+        echo '<style type="text/css">' . $custom_css . '</style>';
+    }
+}
+add_action( 'wp_head', 'coa_load_custom_css' );

--- a/includes/frontend-display.php
+++ b/includes/frontend-display.php
@@ -13,7 +13,7 @@ function coa_inject_cta( $content ) {
         $options = get_option( 'coa_settings' );
         if ( empty( $options ) ) return $content;
 
-        $ctas_to_inject = ['awal' => '', 'tengah' => '', 'akhir' => ''];
+        $ctas_to_inject = ['awal' => '', 'bawah_paragraf_1' => '', 'tengah' => '', 'akhir' => ''];
         $current_post_id = get_the_ID();
         $current_post_categories = wp_get_post_categories($current_post_id, ['fields' => 'ids']);
 
@@ -95,6 +95,17 @@ function coa_inject_cta( $content ) {
 
         if ( ! empty( $ctas_to_inject['awal'] ) ) $content = $ctas_to_inject['awal'] . $content;
         if ( ! empty( $ctas_to_inject['akhir'] ) ) $content = $content . $ctas_to_inject['akhir'];
+
+        if ( ! empty( $ctas_to_inject['bawah_paragraf_1'] ) ) {
+            $paragraphs = explode( '</p>', $content );
+            if ( count( $paragraphs ) > 1 ) {
+                $paragraphs[0] .= '</p>' . $ctas_to_inject['bawah_paragraf_1'];
+                $content = implode( '', $paragraphs );
+            } else {
+                $content .= $ctas_to_inject['bawah_paragraf_1'];
+            }
+        }
+
         if ( ! empty( $ctas_to_inject['tengah'] ) ) {
             $paragraphs = explode( '</p>', $content );
             $paragraph_count = count( $paragraphs );

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -1,0 +1,80 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Fungsi untuk shortcode [cta_kustom].
+ *
+ * Atribut yang didukung:
+ * - heading="Teks Judul Anda"
+ * - telepon="Label Tombol,Nomor Telepon"
+ * - whatsapp="Label Tombol,Nomor WhatsApp"
+ * - url="Label Tombol,URL Lengkap"
+ * - bg_color="#warna"
+ * - btn_color="#warna"
+ * - btn_text_color="#warna"
+ */
+function coa_custom_cta_shortcode( $atts ) {
+    // Atur nilai default
+    $atts = shortcode_atts(
+        [
+            'heading'        => '',
+            'telepon'        => '',
+            'whatsapp'       => '',
+            'url'            => '',
+            'bg_color'       => '#f7f7f7',
+            'btn_color'      => '#0073aa',
+            'btn_text_color' => '#ffffff',
+        ],
+        $atts,
+        'cta_kustom'
+    );
+
+    if ( empty( $atts['heading'] ) ) {
+        return ''; // Jangan tampilkan apa pun jika tidak ada heading
+    }
+
+    $container_style = 'background-color: ' . esc_attr( $atts['bg_color'] ) . ';';
+    $button_style    = 'background-color: ' . esc_attr( $atts['btn_color'] ) . '; color: ' . esc_attr( $atts['btn_text_color'] ) . ';';
+
+    $cta_html = '<div class="coa-cta-container" style="' . $container_style . '">';
+    $cta_html .= '<h3 class="coa-heading">' . esc_html( $atts['heading'] ) . '</h3>';
+    $cta_html .= '<div class="coa-buttons">';
+
+    // Proses tombol-tombol
+    $buttons = [
+        'telepon'  => ['icon' => 'fa-solid fa-phone', 'prefix' => 'tel:'],
+        'whatsapp' => ['icon' => 'fa-brands fa-whatsapp', 'prefix' => 'https://wa.me/'],
+        'url'      => ['icon' => 'fa-solid fa-link', 'prefix' => ''],
+    ];
+
+    foreach ( $buttons as $type => $data ) {
+        if ( ! empty( $atts[ $type ] ) ) {
+            $parts = explode( ',', trim( $atts[ $type ] ), 2 );
+            if ( count( $parts ) === 2 ) {
+                $label = trim( $parts[0] );
+                $value = trim( $parts[1] );
+                $href  = '';
+
+                if ( $type === 'telepon' ) {
+                    $href = $data['prefix'] . preg_replace( '/[^0-9+]/', '', $value );
+                } elseif ( $type === 'whatsapp' ) {
+                    $href = $data['prefix'] . preg_replace( '/\D/', '', $value );
+                } else {
+                    $href = esc_url( $value );
+                }
+
+                $cta_html .= '<a href="' . $href . '" class="coa-button" style="' . $button_style . '" target="_blank" rel="noopener noreferrer">';
+                $cta_html .= '<i class="' . $data['icon'] . '"></i> ' . esc_html( $label );
+                $cta_html .= '</a>';
+            }
+        }
+    }
+
+    $cta_html .= '</div></div>';
+
+    return $cta_html;
+}
+add_shortcode( 'cta_kustom', 'coa_custom_cta_shortcode' );


### PR DESCRIPTION
Menambahkan beberapa fitur baru untuk meningkatkan fungsionalitas plugin CTA Otomatis:

1.  **CSS Kustom**: Menambahkan area teks di halaman pengaturan untuk memungkinkan pengguna memasukkan CSS kustom untuk mengubah gaya CTA.
2.  **Penempatan di Bawah Paragraf Pertama**: Menambahkan opsi baru untuk secara otomatis menampilkan CTA tepat setelah paragraf pertama artikel.
3.  **Shortcode `[cta_kustom]`**: Memperkenalkan shortcode baru yang memungkinkan penempatan CTA secara manual di mana saja di dalam konten, lengkap dengan atribut untuk kustomisasi penuh.